### PR TITLE
Coding test - Chuong Huynh

### DIFF
--- a/app/controllers/api/converters_controller.rb
+++ b/app/controllers/api/converters_controller.rb
@@ -1,0 +1,11 @@
+class Api::ConvertersController < Api::BaseController
+  def convert
+    @converter = Converter.new from_amount: params[:from_amount], from_unit: params[:from_unit], to_unit: params[:to_unit]
+    @error_object = @converter.errors.messages unless @converter.valid?
+    if @error_object.blank?
+      render json: { to_unit: @converter.to_unit, to_amount: @converter.to_amount }
+    else
+      render json: { error: @error_object }, status: :bad_request
+    end
+  end
+end

--- a/app/controllers/api/ratings_controller.rb
+++ b/app/controllers/api/ratings_controller.rb
@@ -1,0 +1,28 @@
+class Api::RatingsController < Api::BaseController
+  before_action :doorkeeper_authorize!, only: %w[index show update destroy]
+  before_action :current_user_authenticate, only: %w[index show update destroy]
+  before_action :recipe
+
+  def index
+    @recipe.ratings
+  end
+
+  def create
+    @rating = @recipe.ratings.build(rating_params.merge({ user: current_user }))
+    if @rating.valid?
+      @rating = @recipe.create_or_update_user_rating(user: current_user, rating: @rating.rating).reload
+    else
+      @error_object = @rating.errors.messages
+    end
+  end
+
+  private
+
+  def recipe
+    @recipe = Recipe.find params[:recipe_id]
+  end
+
+  def rating_params
+    params.require(:rating).permit(:rating)
+  end
+end

--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -44,15 +44,12 @@ class Api::RecipesController < Api::BaseController
   end
 
   def index
-    request = {}
-
-    request.merge!('title' => params.dig(:recipes, :title))
-    request.merge!('descriptions' => params.dig(:recipes, :descriptions))
-    request.merge!('time' => params.dig(:recipes, :time))
-    request.merge!('difficulty' => params.dig(:recipes, :difficulty))
-    request.merge!('category_id' => params.dig(:recipes, :category_id))
-    request.merge!('user_id' => params.dig(:recipes, :user_id))
-
-    @recipes = Recipe.all
+    @recipes = []
+    recipe_query = RecipeQueryService.new title: params[:title], time: params[:time], difficulty: params[:difficulty]
+    if recipe_query.valid?
+      @recipes = recipe_query.execute
+    else
+      @error_object = recipe_query.errors.messages
+    end
   end
 end

--- a/app/models/concerns/constant_validatable.rb
+++ b/app/models/concerns/constant_validatable.rb
@@ -3,4 +3,11 @@ module ConstantValidatable
   KATAKANA_VALIDATION_FORMAT = %r{\A[ァ-ヶー－]+\z} # rubocop:disable Style/RegexpLiteral
   URL_VALIDATION_FORMAT = %r{\A(http|https)://[a-z0-9]+([\-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?\z}
   PHONE_NUMBER_VALIDATION_FORMAT = %r{\A[+]?[(]?[0-9]{3}[)]?[-\s.]?[0-9]{3}[-\s.]?[0-9]{4,6}\z} # rubocop:disable Style/RegexpLiteral
+  TIME_DURATION_VALIDATION_FORMAT = %r{\A(\d+)(?:\s*hours?)\s*(\d+)(?:\s*mins?)|(\d+)(?:\s*hours?)|(\d+)(?:\s*mins?)\z} # rubocop:disable Style/RegexpLiteral
+  TIME_DURATION_RANGE_VALIDATION_FORMAT =
+    /\A
+      ((\d+)(?:\s*hours?)\s*(\d+)(?:\s*mins?)|(\d+)(?:\s*hours?)|(\d+)(?:\s*mins?)) # min time duration
+      \s*-\s*
+      ((\d+)(?:\s*hours?)\s*(\d+)(?:\s*mins?)|(\d+)(?:\s*hours?)|(\d+)(?:\s*mins?)) # max time duration
+    \z/x
 end

--- a/app/models/converter.rb
+++ b/app/models/converter.rb
@@ -1,0 +1,15 @@
+class Converter
+  include ActiveModel::API
+
+  UNIT_RATIOS = { "cup" => 1, "teaspoons" => 48, "gram" => 130, "kilogram" => 0.13 }
+  UNITS = %w[cup teaspoons gram kilogram]
+
+  attr_accessor :from_unit, :to_unit, :from_amount
+
+  validates :from_unit, :to_unit, presence: true, inclusion: UNITS
+  validates :from_amount, presence: true, numericality: true
+
+  def to_amount
+    UNIT_RATIOS[to_unit] * from_amount.to_f / UNIT_RATIOS[from_unit]
+  end
+end

--- a/app/models/ratable.rb
+++ b/app/models/ratable.rb
@@ -1,0 +1,15 @@
+module Ratable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :ratings
+  end
+
+  def create_or_update_user_rating(user:, rating:)
+    rating_record = ratings.find_or_initialize_by(user: user)
+    rating_record.rating = rating
+    rating_record.save
+
+    rating_record
+  end
+end

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,0 +1,12 @@
+class Rating < ApplicationRecord
+  belongs_to :user
+  belongs_to :recipe
+
+  validates :rating, numericality: { only_integer: true, in: 1..5 }, presence: true
+
+  def self.rate(user, recipe, rating)
+    rating_record = Rating.find_or_initialize_by(user: user, recipe: recipe)
+    rating_record.rating = rating
+    rating_record.save
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -22,7 +22,7 @@ class Recipe < ApplicationRecord
   validates :descriptions, length: { maximum: 65_535, minimum: 0, message: I18n.t('.out_of_range_error') },
                            presence: true
 
-  validates :time, length: { maximum: 255, minimum: 0, message: I18n.t('.out_of_range_error') }, presence: true
+  validates :time, length: { maximum: 255, minimum: 0, message: I18n.t('.out_of_range_error') }, format: { with: /(\d+):[0-5]?[0-9]:00/ }, presence: true
 
   validates :difficulty, presence: true
 
@@ -33,6 +33,28 @@ class Recipe < ApplicationRecord
   end
 
   # jitera-anchor-dont-touch: reset_password
+
+  scope :with_difficulty, ->(difficulty) { where(difficulty: difficulty) }
+  scope :title_has, ->(title) { where('title like ?', "%#{title}%") }
+  scope :time_within, ->(min_sec, max_sec) { where('time_to_sec(time) >= ? and time_to_sec(time) <= ?', min_sec, max_sec) }
+
+  def time_string=(ts)
+    m = ts.match(ConstantValidatable::TIME_DURATION_VALIDATION_FORMAT)
+    return if m.nil?
+
+    hr = m[1] || m[3]
+    mn = m[2] || m[4]
+    self.time = "#{hr}:#{mn}:00"
+  end
+
+  def time_string
+    return '' if time.nil?
+
+    time_arr = time.split ':'
+    hr = time_arr[0].to_i
+    mn = time_arr[1].to_i
+    "#{hr} hours #{mn} mins"
+  end
 
   class << self
   end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,5 +1,6 @@
 class Recipe < ApplicationRecord
   include ConstantValidatable
+  include Ratable
 
   # jitera-anchor-dont-touch: relations
 

--- a/app/models/recipe_query_service.rb
+++ b/app/models/recipe_query_service.rb
@@ -1,0 +1,35 @@
+class RecipeQueryService
+  include ActiveModel::API
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :title, :time, :difficulty, :min_sec, :max_sec
+
+  validates :difficulty, inclusion: %w[easy normal challenging], allow_blank: true
+  validates :time, format: { with: ConstantValidatable::TIME_DURATION_RANGE_VALIDATION_FORMAT }, allow_blank: true
+
+  after_validation :set_time_values
+
+  def initialize(title: nil, time: nil, difficulty: nil)
+    @title = title
+    @time = time
+    @difficulty = difficulty
+  end
+
+  def execute
+    q = Recipe.all
+    q = q.title_has(@title) if @title.present?
+    q = q.with_difficulty(Recipe.difficulties[@difficulty]) if @difficulty.present?
+    q = q.time_within(@min_sec, @max_sec) if @min_sec.present?
+    q
+  end
+
+  private
+
+  def set_time_values
+    if errors.empty? && time.present?
+      m = time.match ConstantValidatable::TIME_DURATION_RANGE_VALIDATION_FORMAT
+      @min_sec = (60* m[2].to_i + m[3].to_i + m[4].to_i*60 + m[5].to_i)*60
+      @max_sec = (m[7].to_i*60 + m[8].to_i + m[9].to_i*60 + m[10].to_i)*60
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,11 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :recipes
 
+  def self.authenticate(email, password)
+    user = User.find_for_authentication(email: email)
+    user&.valid_password?(password) ? user : nil
+  end
+
   def self.associations
     [:recipes]
   end

--- a/app/views/api/categories/create.json.jbuilder
+++ b/app/views/api/categories/create.json.jbuilder
@@ -26,7 +26,7 @@ if @error_object.blank?
     end
 
     json.description @category.description
-    json.category_id @category.category_id
+    json.category_id @category.id
   end
 else
   json.error_object @error_object

--- a/app/views/api/categories/index.json.jbuilder
+++ b/app/views/api/categories/index.json.jbuilder
@@ -26,7 +26,7 @@ if @categories.present?
     end
 
     json.description category.description
-    json.category_id category.category_id
+    json.category_id category.id
   end
 else
   json.error_message @error_message

--- a/app/views/api/ratings/create.json.jbuilder
+++ b/app/views/api/ratings/create.json.jbuilder
@@ -1,0 +1,10 @@
+if @error_object.blank?
+  json.rating do
+    json.id @rating.id
+    json.recipe_id @rating.recipe_id
+    json.rater_id @rating.user_id
+    json.rating @rating.rating
+  end
+else
+  json.error @error_object
+end

--- a/app/views/api/ratings/index.json.jbuilder
+++ b/app/views/api/ratings/index.json.jbuilder
@@ -1,0 +1,13 @@
+if @error_message.blank?
+  json.recipe do
+    json.id @recipe.id
+    json.ratings @recipe.ratings do |rating|
+      json.id rating.id
+      json.recipe_id rating.recipe_id
+      json.rater_id rating.user_id
+      json.rating rating.rating
+    end
+  end
+else
+  json.error_message @error_message
+end

--- a/app/views/api/recipes/index.json.jbuilder
+++ b/app/views/api/recipes/index.json.jbuilder
@@ -1,5 +1,5 @@
-if @recipes.present?
-  json.recipes @recipes do |recipe|
+if @error_object.blank?
+  json.recipes @recipes.map do |recipe|
     json.id recipe.id
     json.created_at recipe.created_at
     json.updated_at recipe.updated_at
@@ -21,5 +21,6 @@ if @recipes.present?
     json.user_id recipe.user_id
   end
 else
-  json.error_message @error_message
+  json.recipes []
+  json.errors @error_object
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,16 +7,19 @@ Doorkeeper.configure do
   access_token_generator '::Doorkeeper::JWT'
 
   # This block will be called to check whether the resource owner is authenticated or not.
-  resource_owner_authenticator do
-    raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
-    # Put your resource owner authentication logic here.
-    # Example implementation:
-    #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
-  end
+  # resource_owner_authenticator do
+  #   raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
+  #   # Put your resource owner authentication logic here.
+  #   # Example implementation:
+  #   #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
+  # end
 
   # resource_owner_from_credentials do |_routes|
   # User.authenticate(params[:email], params[:password])
   # end
+  resource_owner_from_credentials do
+    User.authenticate(params[:email], params[:password])
+  end
 
   # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
   # file then you need to declare this block in order to restrict access to the web interface for
@@ -220,7 +223,7 @@ Doorkeeper.configure do
   # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
   # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
   #
-  # use_refresh_token
+  use_refresh_token
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
@@ -355,6 +358,7 @@ Doorkeeper.configure do
   #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
   #
   # grant_flows %w[authorization_code client_credentials]
+  grant_flows %w[password]
 
   # Allows to customize OAuth grant flows that +each+ application support.
   # You can configure a custom block (or use a class respond to `#call`) that must

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   authentication_error: Unauthorized
   file_exists_label: File already exists
+  out_of_range_error: Value out of range
   mobile:
     wrong_credentials: Wrong credentials
     user_not_registered: User is not registered

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,54 +7,57 @@ module ActionDispatch
         routes_path = Rails.root.join('config', 'routes', (@scope[:shallow_prefix]).to_s, "#{routes_name}.rb")
 
         instance_eval(File.read(routes_path))
-     end
+      end
     end
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
-use_doorkeeper
-      mount Rswag::Ui::Engine => '/api-docs'
-      mount Rswag::Api::Engine => '/api-docs'
+  # use_doorkeeper
+  use_doorkeeper do
+    skip_controllers :authorizations, :applications, :authorized_applications
+  end
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   get '/health' => 'pages#health_check'
 
   namespace :api do
-put '/users_passwords', to: 'users_passwords#put_users_passwords'
-resources :users_registrations, only: [:create] do
- end
+    put '/users_passwords', to: 'users_passwords#put_users_passwords'
+    resources :users_registrations, only: [:create] do
+    end
 
-resources :users_verify_reset_password_requests, only: [:create] do
- end
+    resources :users_verify_reset_password_requests, only: [:create] do
+    end
 
-resources :users_reset_password_requests, only: [:create] do
- end
+    resources :users_reset_password_requests, only: [:create] do
+    end
 
-resources :users_sessions, only: [:create] do
- end
+    resources :users_sessions, only: [:create] do
+    end
 
-resources :ingredients, only: [:index, :create, :show, :update, :destroy] do
- end
+    resources :ingredients, only: %i[index create show update destroy] do
+    end
 
-resources :categories, only: [:index, :create, :show, :update, :destroy] do
- end
+    resources :categories, only: %i[index create show update destroy] do
+    end
 
-resources :recipes, only: [:index, :create, :show, :update, :destroy] do
- end
+    resources :recipes, only: %i[index create show update destroy] do
+    end
 
+    get '/converters/convert', to: 'converters#convert'
   end
 
   # jitera-anchor-dont-touch: webhooks
 
   namespace :dashboard do
     # TODO: customizable table name
-    
-
   end
 
   unless Rails.env.development?
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-      admin_username = ENV['SIDEKIQ_DASHBOARD_USERNAME']
-      admin_password = ENV['SIDEKIQ_DASHBOARD_PASSWORD']
+      admin_username = ENV.fetch('SIDEKIQ_DASHBOARD_USERNAME', nil)
+      admin_password = ENV.fetch('SIDEKIQ_DASHBOARD_PASSWORD', nil)
       ActiveSupport::SecurityUtils.secure_compare(
         ::Digest::SHA256.hexdigest(username),
         ::Digest::SHA256.hexdigest(admin_username)
@@ -66,3 +69,4 @@ resources :recipes, only: [:index, :create, :show, :update, :destroy] do
   end
   mount Sidekiq::Web => '/sidekiq'
 end
+# rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     end
 
     resources :recipes, only: %i[index create show update destroy] do
+      resources :ratings, only: %i[index create]
     end
 
     get '/converters/convert', to: 'converters#convert'

--- a/db/migrate/20221028041904_create_ratings.rb
+++ b/db/migrate/20221028041904_create_ratings.rb
@@ -1,0 +1,11 @@
+class CreateRatings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ratings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+      t.integer :rating
+
+      t.timestamps
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,11 @@
+if Doorkeeper::Application.count.zero?
+  Doorkeeper::Application.create!(name: 'Web Client', redirect_uri: '', scopes: '')
+  # other applications
+end
 
+User.create(email: 'user1@example.com',
+                     password: 'password',
+                     password_confirmation: 'password')
+User.create(email: 'user2@example.com',
+                     password: 'password',
+                     password_confirmation: 'password')

--- a/spec/factories/ratings.rb
+++ b/spec/factories/ratings.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :rating do
+    user { nil }
+    recipe { nil }
+    rating { 1 }
+  end
+end

--- a/spec/factories/recipe.rb
+++ b/spec/factories/recipe.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     # jitera-anchor-dont-touch: columns
     difficulty { 'easy' }
-    time { Faker::Lorem.paragraph_by_chars(number: rand(0..255)) }
+    time { '1:30:00' }
     descriptions { Faker::Lorem.paragraph_by_chars(number: rand(0..1000)) }
     title { Faker::Lorem.paragraph_by_chars(number: rand(0..255)) }
   end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Rating, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/converters_spec.rb
+++ b/spec/requests/api/converters_spec.rb
@@ -1,0 +1,40 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/converters', type: :request do
+  path '/api/converters/convert' do
+    get 'Make conversion' do
+      consumes 'application/json'
+      parameter name: :from_amount, in: :query, type: :string
+      parameter name: :from_unit, in: :query, type: :string
+      parameter name: :to_unit, in: :query, type: :string
+
+      response '200', 'successful' do
+        let(:from_amount) { 1 }
+        let(:from_unit) { 'cup' }
+        let(:to_unit) { 'teaspoons' }
+        run_test! do |response|
+          puts response.body.inspect
+          expect(response.status).to eq(200)
+          expect(JSON.parse(response.body)).to eq({ "to_unit" => 'teaspoons', "to_amount" => 48.0 })
+        end
+      end
+
+      response '400', 'invalid parameters' do
+        [
+          { from_unit: 'cup', to_unit: 'teaspoons' },
+          { from_unit: 'cup', from_amount: 1.1 },
+          { from_unit: 'cup_x', from_amount: 1.1, to_unit: 'teaspoons' },
+          { from_unit: 'cup', from_amount: 'a', to_unit: 'teaspoons' }
+        ].each do |params|
+          let(:from_amount) { params[:from_amount] }
+          let(:from_unit) { params[:from_unit] }
+          let(:to_unit) { params[:to_unit] }
+
+          run_test! do |response|
+            expect(response.status).to eq(400)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/ingredients_spec.rb
+++ b/spec/requests/api/ingredients_spec.rb
@@ -263,8 +263,6 @@ RSpec.describe 'api/ingredients', type: :request do
 
             'updated_at' => 'datetime',
 
-            'unit' => 'float',
-
             'unit' => 'enum_type',
 
             'amount' => 'float',

--- a/spec/requests/api/ratings_spec.rb
+++ b/spec/requests/api/ratings_spec.rb
@@ -1,0 +1,66 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/recipes/{recipe_id}/ratings', type: :request do
+  path '/api/recipes/{recipe_id}/ratings' do
+    get 'List ratings for a recipe' do
+      tags 'filter'
+      consumes 'application/json'
+
+      security [bearerAuth: []]
+      parameter name: 'recipe_id', in: :path, type: 'string', description: 'recipe_id'
+      response '200', 'filter' do
+        examples 'application/json' => {
+        }
+        let(:resource_owner) { create(:user) }
+        let(:token) { create(:access_token, resource_owner: resource_owner).token }
+        let(:Authorization) { "Bearer #{token}" }
+        let(:recipe_id) { create(:recipe).id }
+        run_test! do |response|
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+
+  path '/api/recipes/{recipe_id}/ratings' do
+    post 'Rate a recipe' do
+      tags 'create'
+      consumes 'application/json'
+
+      security [bearerAuth: []]
+      parameter name: 'recipe_id', in: :path, type: 'string', description: 'recipe_id'
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+          rating: {
+            type: :object,
+            properties: {
+              rating: {
+                type: :integer,
+                example: 5
+              }
+            }
+          }
+        }
+      }
+      response '200', 'create' do
+        examples 'application/json' => {
+          'rating' => {
+            'id' => 'integer',
+            "recipe_id" => "foreign_key",
+            "rater_id" => "foreign_key",
+            "rating" => "integer"
+          }
+        }
+        let(:resource_owner) { create(:user) }
+        let(:token) { create(:access_token, resource_owner: resource_owner).token }
+        let(:Authorization) { "Bearer #{token}" }
+        let(:recipe_id) { create(:recipe).id }
+        let(:params) { { rating: { rating: 2 } } }
+        run_test! do |response|
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/recipes_spec.rb
+++ b/spec/requests/api/recipes_spec.rb
@@ -358,54 +358,10 @@ RSpec.describe 'api/recipes', type: :request do
       consumes 'application/json'
 
       security [bearerAuth: []]
-      parameter name: :params, in: :body, schema: {
-        type: :object,
-        properties: {
-          recipes: {
-            type: :object,
-            properties: {
-              title: {
-                type: :string,
-                example: 'string'
-              },
+      parameter name: :title, in: :query, type: :string, required: false
+      parameter name: :difficulty, in: :query, type: :string, required: false
+      parameter name: :time, in: :query, type: :string, required: false
 
-              descriptions: {
-                type: :text,
-                example: 'text'
-              },
-
-              time: {
-                type: :string,
-                example: 'string'
-              },
-
-              difficulty: {
-                type: :enum_type,
-                example: 'enum_type'
-              },
-
-              category_id: {
-                type: :foreign_key,
-                example: 'foreign_key'
-              },
-
-              user_id: {
-                type: :foreign_key,
-                example: 'foreign_key'
-              }
-
-            }
-          },
-          pagination_page: {
-            type: :pagination_page,
-            example: 'pagination_page'
-          },
-          pagination_limit: {
-            type: :pagination_limit,
-            example: 'pagination_limit'
-          }
-        }
-      }
       response '200', 'filter' do
         examples 'application/json' => {
           'total_pages' => 'integer',
@@ -461,7 +417,7 @@ RSpec.describe 'api/recipes', type: :request do
         let(:resource_owner) { create(:user) }
         let(:token) { create(:access_token, resource_owner: resource_owner).token }
         let(:Authorization) { "Bearer #{token}" }
-        let(:params) {}
+
         run_test! do |response|
           expect(response.status).to eq(200)
         end


### PR DESCRIPTION
## Overview
Please write the overview about this PR.

## What's in this PR:

### 0. Authentication
- Even though authentication, I've configured DoorKeeper to enable sign-in/sign-out at:
  - /oauth/token
  - /oauth/revoke

The authentication will be needed in some actions, like Rating, List Recipes...

- I've also added seed data with 1 web application in `oauth_applications` and 2 users;
- Parameters to used for signing in: beside email and password, one would also need:
  -  `client_id`, `client_secrete`, which are `uid`, `secrete` in `oauth_applications`
  - grant_type = 'password'

### 1. Search recipes: `/api/recipes` has been updated to have filter/search feature

_Note about filter by time range:_
- To efficiently query by time range, I assumed the data saved into recipes#time field is in format: hh:mm:ss
- A rough implementation of `Recipe#time_string=(st)` and `Recipe#time_string` to set/get string format of `time` field
- time param can be a little flexible in format, e.g.:
  -  1 hour 30 mins
  - 1hour 30mins
  - 2 hours 
  - 45mins
  - ...


### 2. Weight converter: `GET /api/converters/convert`
- I'm not sure I understand the requirement correctly, but this converter is implemented as fixed, regardless ingredient.
- It requires 3 parameters:
  - from_unit
  - from_amount
  - to_unit
e.g `/api/converters/convert?from_unit=cup&to_unit=gram&from_amount=5`

- In my opinion, converter should be dependent on ingredient. (A cup of water and a cup of sugar will be corresponding to different number of grams

BTW, I also think an ingredient should have a name

### 3. Rating: APIs for this feature require authentication (Bear)
- APIs are provided to allow a user to 
  - rate/update rating (from 1-5) on a recipe
  - view rating list of a particular recipe
